### PR TITLE
fix: cancel actually aborts in-flight pipeline requests

### DIFF
--- a/apps/web/src/routes/workflows/reports/[slug]/+page.server.ts
+++ b/apps/web/src/routes/workflows/reports/[slug]/+page.server.ts
@@ -3,9 +3,9 @@ import { getLastPipelineMetricForConfig } from '$lib/server/logger/configMetrics
 import type { ConfigRunner } from '@onaio/symbology-calc-core';
 
 /** @type {import('./$types').PageLoad} */
-export function load({params}) {
+export function load({ params }) {
 	const uuid = params.slug ?? '';
-	const configs = getClientSideSymbologyConfigs().filter(config => config.uuid === uuid);
+	const configs = getClientSideSymbologyConfigs().filter((config) => config.uuid === uuid);
 	const ConfigsWithMetrics = configs.map((config) => {
 		const configId = config.uuid;
 		const metricForThisConfig = getLastPipelineMetricForConfig(configId);

--- a/apps/web/src/routes/workflows/reports/[slug]/utils.ts
+++ b/apps/web/src/routes/workflows/reports/[slug]/utils.ts
@@ -40,21 +40,22 @@ export function formatTimestamp(timeStamp: number) {
 	return new Date(timeStamp).toLocaleString();
 }
 
-
-export function formatTriggerDuration(start?: number, end?: number, isRunning=false){
-	if (start && end){
-		return `${formatTimestamp(start)}  to  ${formatTimestamp(end)} (${((end - start) / 60000).toFixed(0)} mins)`
+export function formatTriggerDuration(start?: number, end?: number, isRunning = false) {
+	if (start && end) {
+		return `${formatTimestamp(start)}  to  ${formatTimestamp(end)} (${(
+			(end - start) /
+			60000
+		).toFixed(0)} mins)`;
 	}
-	if(!start){
-		return `Unable to determine when pipeline was started`
+	if (!start) {
+		return `Unable to determine when pipeline was started`;
 	}
-	if(!end){
-		if(isRunning){
-			const runningFor = ((Date.now() - start) / 60000).toFixed(0)
-			return `Started at: ${formatTimestamp(start)}; (Running for ${runningFor} mins)`
-		}
-		else{
-			return `Started at: ${formatTimestamp(start)}; (Ran cancelled before completion)`
+	if (!end) {
+		if (isRunning) {
+			const runningFor = ((Date.now() - start) / 60000).toFixed(0);
+			return `Started at: ${formatTimestamp(start)}; (Running for ${runningFor} mins)`;
+		} else {
+			return `Started at: ${formatTimestamp(start)}; (Ran cancelled before completion)`;
 		}
 	}
 }

--- a/apps/web/src/routes/workflows/utils.ts
+++ b/apps/web/src/routes/workflows/utils.ts
@@ -1,6 +1,5 @@
 import cronstrue from 'cronstrue';
 
-
 /** Converts a cron syntax string to huma readable string
  * @param cronString - cron-like syntax string.
  */

--- a/packages/core/src/evaluator/configRunner.ts
+++ b/packages/core/src/evaluator/configRunner.ts
@@ -37,22 +37,18 @@ export class ConfigRunner {
   public config: Config;
   /** Whether pipeline/runner is currently evaluating */
   private running = false;
-  /** request abort controller */
-  // private abortController;
+  /** request abort controller — replaced per transform() so cancel halts only the current run */
+  private abortController?: AbortController;
   /** stores validity of config */
   public invalidError: string | null = null;
-  /** metric category store for each run */
-  // private reporter: ReportMetric;
 
   constructor(config: Config) {
     this.config = config;
-    // this.abortController = new AbortController();
     try {
       validateConfigs(config);
     } catch (err: unknown) {
       this.invalidError = (err as Error).message;
     }
-    // this.reporter = new ReportMetric(config.uuid);
   }
 
   /** Runs the pipeline, generator that yields metric information regarding the current run */
@@ -77,13 +73,15 @@ export class ConfigRunner {
     let totalRegFormSubmissions = 0;
     yield reporter.generateJsonReport();
 
-    // const service = new OnaApiService(baseUrl, apiToken, logger, this.abortController);
-    const service = new OnaApiService(baseUrl, apiToken, logger);
+    const service = new OnaApiService(baseUrl, apiToken, logger, this.abortController);
     const colorDecider = colorDeciderFactory(symbolConfig, logger);
 
     abortableBlock: {
       const regForm = await service.fetchSingleForm(regFormId);
       if (regForm.isFailure) {
+        if (regForm.detail?.code === EVALUATION_ABORTED) {
+          break abortableBlock;
+        }
         reporter.updateGeneralError(`Fetching form with id ${regFormId} failed due to : ${regForm.error}`)
         yield reporter.generateJsonReport(true);
         return;
@@ -157,6 +155,9 @@ export class ConfigRunner {
 
         let cursor = 0;
         while (cursor <= updateRegFormSubmissionsPromises.length) {
+          if (this.abortController?.signal.aborted) {
+            break abortableBlock;
+          }
           const end = cursor + editSubmissionsChunks;
           const chunksToSend = updateRegFormSubmissionsPromises.slice(cursor, end);
           cursor = cursor + editSubmissionsChunks;
@@ -181,19 +182,21 @@ export class ConfigRunner {
     if (this.invalidError) {
       return Result.fail(`Configuration is not valid, ${this.invalidError}`);
     }
-    // create a function that parses the config and supplies default values.
     const WriteMetric = config.writeMetric ?? defaultWriteMetric;
     if (this.running) {
       return Result.fail('Pipeline is already running.');
-    } else {
-      this.running = true;
+    }
+    this.running = true;
+    this.abortController = new AbortController();
+    try {
       let finalMetric;
       for await (const metric of this.transformGenerator(triggeredVia)) {
         WriteMetric(metric as any);
         finalMetric = metric;
       }
-      this.running = false;
       return Result.ok(finalMetric);
+    } finally {
+      this.running = false;
     }
   }
 
@@ -209,13 +212,12 @@ export class ConfigRunner {
     return task;
   }
 
-  /** Cancel evaluation using a configured abortController */
+  /** Cancel the in-flight evaluation by aborting outstanding HTTP requests. */
   cancel() {
-    // const abortController = this.abortController;
     if (!this.running) {
       return;
     }
-    // abortController.abort();
+    this.abortController?.abort();
     return Result.ok();
   }
 

--- a/packages/core/src/evaluator/tests/helpers.test.ts
+++ b/packages/core/src/evaluator/tests/helpers.test.ts
@@ -236,17 +236,13 @@ describe('transform facility tests', () => {
     );
 
     controller.abort();
-    await response.then((value) => {
-      expect(value).toEqual({
-        _value: undefined,
-        detail: {
-          code: 'ECODE3',
-          recsAffected: 0
-        },
-        "error": "Error Name: AbortError | Message: The user aborted a request.",
-        isFailure: true,
-        isSuccess: false
-      });
+    const value = await response;
+    expect(value.isFailure).toBe(true);
+    expect(value.isSuccess).toBe(false);
+    expect(value.error).toBe('Error Name: AbortError | Message: The user aborted a request.');
+    expect(value.detail).toEqual({
+      code: 'ECODE1',
+      recsAffected: 0
     });
   });
 });

--- a/packages/core/src/evaluator/tests/pipelinesController.test.ts
+++ b/packages/core/src/evaluator/tests/pipelinesController.test.ts
@@ -286,4 +286,61 @@ test('runOnSchedule without configId schedules all pipelines', () => {
   expect(taskStrings).toContain('task-0 6 */7 * *'); // config2 schedule
 });
 
-// can cancel evaluation.
+test('cancel aborts in-flight requests and a subsequent transform runs with a fresh controller', async () => {
+  const loggerMock = jest.fn();
+  const configs = createConfigs(loggerMock);
+
+  // Hold the form fetch open long enough to cancel before it returns. No
+  // submissions/edit mocks are registered — if cancel does not abort cleanly,
+  // the pipeline would hit nock.disableNetConnect and fail the test.
+  nock(configs.baseUrl).get(`/${formEndpoint}/3623`).delay(2000).reply(200, form3623);
+
+  const pipelinesController = new PipelinesController(() => [configs]);
+  const runner = pipelinesController.getPipelines(configs.uuid) as ConfigRunner;
+
+  const firstRun = runner.transform();
+  await flushPromises();
+  expect(runner.isRunning()).toBe(true);
+
+  runner.cancel();
+  const firstResult = await firstRun;
+
+  expect(runner.isRunning()).toBe(false);
+  expect(firstResult.isSuccess).toBe(true);
+  expect(nock.pendingMocks()).toEqual([]);
+
+  const abortLogged = loggerMock.mock.calls.some(
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    ([entry]: any[]) =>
+      entry?.level === 'info' &&
+      typeof entry?.message === 'string' &&
+      entry.message.includes('Aborted fetch for form: 3623')
+  );
+  expect(abortLogged).toBe(true);
+
+  // Second run proves the AbortController was rotated — otherwise the new
+  // transform would be born already-aborted and would not reach a state where
+  // isRunning is true and a fresh abort log is emitted.
+  loggerMock.mockClear();
+  nock(configs.baseUrl).get(`/${formEndpoint}/3623`).delay(2000).reply(200, form3623);
+
+  const secondRun = runner.transform();
+  await flushPromises();
+  expect(runner.isRunning()).toBe(true);
+
+  runner.cancel();
+  const secondResult = await secondRun;
+
+  expect(runner.isRunning()).toBe(false);
+  expect(secondResult.isSuccess).toBe(true);
+  expect(nock.pendingMocks()).toEqual([]);
+
+  const secondAbortLogged = loggerMock.mock.calls.some(
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    ([entry]: any[]) =>
+      entry?.level === 'info' &&
+      typeof entry?.message === 'string' &&
+      entry.message.includes('Aborted fetch for form: 3623')
+  );
+  expect(secondAbortLogged).toBe(true);
+});

--- a/packages/core/src/services/onaApi/services.ts
+++ b/packages/core/src/services/onaApi/services.ts
@@ -10,7 +10,7 @@ import { v4 } from 'uuid';
 import { BaseFormSubmission, Color, Form, LogFn, RegFormSubmission } from '../../helpers/types';
 import { createErrorLog, createInfoLog, createVerboseLog } from '../../helpers/utils';
 import fetchRetry, { RequestInitWithRetry } from 'fetch-retry';
-import { NETWORK_ERROR, Result } from '../../helpers/Result';
+import { EVALUATION_ABORTED, NETWORK_ERROR, Result } from '../../helpers/Result';
 
 const persistentFetch = fetchRetry(fetch);
 
@@ -102,11 +102,18 @@ export class OnaApiService {
         return Result.ok<Form>(res);
       })
       .catch((err: Error) => {
-        const failResult = Result.fail<Form>(err, NETWORK_ERROR)
-        this.logger?.(
-          createErrorLog(`Operation to fetch form: ${formId}, failed with err: ${failResult.error}`)
-        );
-        return failResult
+        const code = err.name === AbortErrorName ? EVALUATION_ABORTED : NETWORK_ERROR;
+        const failResult = Result.fail<Form>(err, code);
+        if (code === EVALUATION_ABORTED) {
+          this.logger?.(createInfoLog(`Aborted fetch for form: ${formId}`));
+        } else {
+          this.logger?.(
+            createErrorLog(
+              `Operation to fetch form: ${formId}, failed with err: ${failResult.error}`
+            )
+          );
+        }
+        return failResult;
       });
   }
 
@@ -184,18 +191,26 @@ export class OnaApiService {
           return Result.ok(res);
         })
         .catch((err: Error) => {
-          
           let recsAffected = pageSize;
-          if ((totalSubmissions - (page * pageSize)) < pageSize) [
-            recsAffected = totalSubmissions - (page * pageSize)
-          ]
-          const failResult =  Result.fail<FormSubmissionT[]>(err, { code: NETWORK_ERROR, recsAffected, });
-          this.logger?.(
-            createErrorLog(
-              `Unable to fetch submissions for form id: ${formId} page: ${paginatedSubmissionsUrl} with err : ${failResult.error}`
-            )
-          );
-          return failResult
+          if ((totalSubmissions - (page * pageSize)) < pageSize) {
+            recsAffected = totalSubmissions - (page * pageSize);
+          }
+          const code = err.name === AbortErrorName ? EVALUATION_ABORTED : NETWORK_ERROR;
+          const failResult = Result.fail<FormSubmissionT[]>(err, { code, recsAffected });
+          if (code === EVALUATION_ABORTED) {
+            this.logger?.(
+              createInfoLog(
+                `Aborted submissions fetch for form id: ${formId} page: ${paginatedSubmissionsUrl}`
+              )
+            );
+          } else {
+            this.logger?.(
+              createErrorLog(
+                `Unable to fetch submissions for form id: ${formId} page: ${paginatedSubmissionsUrl} with err : ${failResult.error}`
+              )
+            );
+          }
+          return failResult;
         });
     } while (page * pageSize <= totalSubmissions);
   }
@@ -241,13 +256,22 @@ export class OnaApiService {
         );
         return Result.ok<Record<string, string>>(res);
       })
-      .catch((err) => {
-        const failResult = Result.fail(err, NETWORK_ERROR)
-        this.logger?.(
-          createErrorLog(
-            `Failed to edit sumbission with _id: ${submissionPayload._id} for form with id: ${formId} with err: ${failResult.error}`
-          )
-        );
+      .catch((err: Error) => {
+        const code = err.name === AbortErrorName ? EVALUATION_ABORTED : NETWORK_ERROR;
+        const failResult = Result.fail(err, code);
+        if (code === EVALUATION_ABORTED) {
+          this.logger?.(
+            createInfoLog(
+              `Aborted edit for submission _id: ${submissionPayload._id} for form: ${formId}`
+            )
+          );
+        } else {
+          this.logger?.(
+            createErrorLog(
+              `Failed to edit sumbission with _id: ${submissionPayload._id} for form with id: ${formId} with err: ${failResult.error}`
+            )
+          );
+        }
         return failResult;
       });
   }


### PR DESCRIPTION
## Summary
- `ConfigRunner.cancel()` was a no-op (the `AbortController` was commented out), so when `refreshConfigRunners` swapped in a new runner the orphaned old runner kept editing submissions while the new runner's next cron tick also fired — producing duplicate `editSubmission` POSTs against onadata.
- Re-enable the `AbortController` per `transform()` call (so a previous abort doesn't poison the next run), surface `AbortError` as `EVALUATION_ABORTED` in `OnaApiService.fetchSingleForm` / `fetchPaginatedFormSubmissionsGenerator` / `editSubmission` so the existing `abortableBlock` branch in `transformGenerator` actually triggers, and check the abort signal between edit-submission chunks so cancel halts in-flight edits early.

## Why duplicates happened
`onadata` dedups submissions only by the *current* `instanceID` (`logger_tools.py:600`). Each in-flight runner generates a fresh UUID per edit, so two concurrent runs editing the same facility produce two new `Instance` rows even though they refer to the same logical record. Stopping the cron task isn't enough — the in-flight HTTP work has to be aborted.

## Test plan
- [x] `yarn workspace @onaio/symbology-calc-core test` — 16/16 passing, including the new `cancel aborts in-flight requests and a subsequent transform runs with a fresh controller` test.
- [x] `yarn turbo run lint --filter=@onaio/symbology-calc-core` — 0 errors (8 pre-existing warnings in untouched files).
- [x] Updated the existing `cancelling request works` assertion in `helpers.test.ts` to expect `EVALUATION_ABORTED` (ECODE1) instead of the old incorrect `NETWORK_ERROR` (ECODE3).
- [ ] Manual verification on staging: trigger a long-running pipeline, save the config file mid-run, confirm only one round of edits lands on the affected facilities.