### PR TITLE
fix: coerce symbolConfig frequency and overFlowDays to numbers

### DIFF
--- a/packages/core/src/evaluator/configRunner.ts
+++ b/packages/core/src/evaluator/configRunner.ts
@@ -65,8 +65,10 @@ export class ConfigRunner {
       regFormSubmissionChunks: facilityProcessingChunks,
       editSubmissionChunks: facilityEditChunks
     } = config;
-    const regFormSubmissionChunks = facilityProcessingChunks ?? 1000;
-    const editSubmissionsChunks = facilityEditChunks ?? 100;
+    // Coerce to numbers — JSON configs can carry these as strings, and string + number
+    // in the cursor arithmetic below silently corrupts the chunk loop.
+    const regFormSubmissionChunks = Number(facilityProcessingChunks ?? 1000);
+    const editSubmissionsChunks = Number(facilityEditChunks ?? 100);
     const reporter = new ReportMetric(configId);
     reporter.updateStart(triggeredVia);
 

--- a/packages/core/src/evaluator/tests/pipelinesController.test.ts
+++ b/packages/core/src/evaluator/tests/pipelinesController.test.ts
@@ -160,6 +160,92 @@ it('works correctly nominal case', async () => {
   expect(nock.pendingMocks()).toEqual([]);
 });
 
+it('accepts string-typed chunk sizes from JSON-loaded configs', async () => {
+  // JSON-loaded configs deliver `regFormSubmissionChunks` and `editSubmissionChunks`
+  // as strings even though the Config type declares them as numbers. The chunk loop
+  // in transformGenerator does `cursor = cursor + editSubmissionsChunks`, which
+  // silently flips cursor to a string and grows it each iteration. Array.prototype.slice
+  // coerces the string indices, so the same total facilities still get processed —
+  // which is why this is a smoke test, not a behavioural diff. The point is to lock
+  // in that string inputs flow through to the same metric output as numeric inputs.
+  const loggerMock = jest.fn();
+  const configs = {
+    ...createConfigs(loggerMock),
+    regFormSubmissionChunks: '1000' as unknown as number,
+    editSubmissionChunks: '100' as unknown as number
+  };
+
+  nock(configs.baseUrl).get(`/${formEndpoint}/3623`).reply(200, form3623);
+
+  nock(configs.baseUrl)
+    .get(`/${submittedDataEndpoint}/3623`)
+    .query({ page_size: 1000, page: 1 })
+    .reply(200, form3623Submissions);
+
+  form3623Submissions.forEach((submission) => {
+    const facilityId = submission._id;
+    nock(configs.baseUrl)
+      .get(`/${submittedDataEndpoint}/3624`)
+      .query({
+        page_size: 1,
+        page: 1,
+        query: `{"facility": ${facilityId}}`,
+        sort: '{"endtime": -1}'
+      })
+      .reply(
+        200,
+        form3624Submissions.filter((sub) => `${sub.facility}` === `${submission._id}`)
+      );
+
+    const submissionsWithValidPost = [
+      304870, 304871, 304872, 304873, 304874, 304889, 304890, 304892
+    ];
+    if (!submissionsWithValidPost.includes(facilityId)) {
+      return;
+    }
+
+    nock(configs.baseUrl)
+      .post(`/${editSubmissionEndpoint}`, {
+        id: '3623',
+        submission: {
+          ...submission,
+          'marker-color': 'red',
+          meta: {
+            instanceID: 'uuid:0af4f147-d5fd-486a-bf76-d1bf850cc976',
+            deprecatedID: submission['meta/instanceID']
+          }
+        }
+      })
+      .reply(201, {
+        message: 'Successful submission.',
+        formid: 'cameroon_iss_registration_v2_1'
+      });
+  });
+
+  const pipelinesController = new PipelinesController(() => [configs]);
+  const runner = pipelinesController.getPipelines(configs.uuid) as ConfigRunner;
+  const metric = await runner.transform();
+
+  expect(metric.getValue()).toEqual({
+    configId: 'uuid',
+    facilitiesEvaluated: {
+      modified: { red: 8, total: 8 },
+      notModified: {
+        ECODE2: { description: 'Facility does not have a priority level', total: 2 },
+        total: 2
+      },
+      total: 10
+    },
+    facilitiesNotEvaluated: { total: 0 },
+    totalFacilities: 10,
+    totalFacilitiesEvaluated: 10,
+    trigger: { by: 'schedule', from: 1673275673342, to: 1673275673342, tookMills: 0 }
+  });
+
+  await flushPromises();
+  expect(nock.pendingMocks()).toEqual([]);
+});
+
 it('error when fetching the registration form', async () => {
   const loggerMock = jest.fn();
   const configs = createConfigs(loggerMock);

--- a/packages/core/src/helpers/tests/utils.test.ts
+++ b/packages/core/src/helpers/tests/utils.test.ts
@@ -1,5 +1,5 @@
 import { createConfigs, form3623Submissions } from '../../evaluator/tests/fixtures/fixtures';
-import { LogMessageLevels, RegFormSubmission } from '../types';
+import { LogMessageLevels, PriorityLevel, RegFormSubmission, SymbologyConfig } from '../types';
 import {
   colorDeciderFactory,
   createDebugLog,
@@ -67,5 +67,27 @@ describe('colorDecider', () => {
     expect(colorDecider(31, submission).getValue()).toEqual('red');
     expect(colorDecider(32, submission).getValue()).toEqual('red');
     expect(colorDecider(99999, submission).getValue()).toEqual('red');
+  });
+
+  // Regression: production JSON configs deliver frequency and overFlowDays as strings.
+  // The decider must coerce them before arithmetic; otherwise "30" + "0" yields "300"
+  // and Low-priority facilities stay green for up to 300 days instead of 30.
+  it('Treats string-typed frequency and overFlowDays as numbers', () => {
+    const stringTypedConfig = [
+      {
+        priorityLevel: PriorityLevel.LOW,
+        frequency: '30' as unknown as number,
+        symbologyOnOverflow: [
+          { overFlowDays: '0' as unknown as number, color: 'green' },
+          { overFlowDays: '1' as unknown as number, color: 'red' }
+        ]
+      }
+    ] as SymbologyConfig;
+    const decider = colorDeciderFactory(stringTypedConfig, jest.fn());
+    const submission = form3623Submissions[2] as RegFormSubmission;
+    expect(decider(30, submission).getValue()).toEqual('green');
+    expect(decider(31, submission).getValue()).toEqual('red');
+    expect(decider(87, submission).getValue()).toEqual('red');
+    expect(decider(300, submission).getValue()).toEqual('red');
   });
 });

--- a/packages/core/src/helpers/utils.ts
+++ b/packages/core/src/helpers/utils.ts
@@ -23,16 +23,19 @@ export const createErrorLog = (message: string) => ({ level: LogMessageLevels.ER
 export const createDebugLog = (message: string) => ({ level: LogMessageLevels.DEBUG, message });
 export const createVerboseLog = (message: string) => ({ level: LogMessageLevels.VERBOSE, message });
 
-/** for each priority level order the symbology on overflow such that the overflow days are in ascending order. */
+/** for each priority level order the symbology on overflow such that the overflow days are in ascending order.
+ * Also coerces `frequency` and `overFlowDays` to numbers — the loaded JSON config can carry them as
+ * strings, which would silently break the `frequency + overFlowDays` arithmetic in `colorDecider`
+ * (string concatenation instead of addition). */
 const orderSymbologyConfig = (config: SymbologyConfig) => {
   return config.map(({ priorityLevel, symbologyOnOverflow, frequency }) => {
-    const unorderedOverFlowDays = symbologyOnOverflow;
     return {
       priorityLevel,
-      frequency,
-      symbologyOnOverflow: unorderedOverFlowDays.slice().sort((overFlow1, overFlow2) => {
-        return overFlow1.overFlowDays - overFlow2.overFlowDays;
-      })
+      frequency: Number(frequency),
+      symbologyOnOverflow: symbologyOnOverflow
+        .slice()
+        .map(({ overFlowDays, color }) => ({ overFlowDays: Number(overFlowDays), color }))
+        .sort((overFlow1, overFlow2) => overFlow1.overFlowDays - overFlow2.overFlowDays)
     };
   });
 };


### PR DESCRIPTION
## Summary

- Coerce `frequency` and `overFlowDays` to numbers inside `orderSymbologyConfig` (`packages/core/src/helpers/utils.ts`). The fields are typed as `number` but the production JSON config delivers them as strings, and `validateConfigs` discards the yup-cast return value — so strings reach `colorDecider` and `frequency + overFlowDays` concatenates instead of adding.
- Net effect of the bug: a `Low` priority with frequency `"30"` and overflow `"0"` yields the threshold `"300"`, so facilities stayed green for up to 300 days instead of 30. The same 10x inflation hits every priority band. ~2,400 facilities are observably stuck on green across the deployed configs.
- Adds a regression test feeding a string-typed `SymbologyConfig` through `colorDeciderFactory` and asserting numeric band selection at the boundary days.
