### PR TITLE
feat: add per-error timestamps to network error samples in report

### DIFF
--- a/apps/web/src/routes/workflows/reports/[slug]/+page.svelte
+++ b/apps/web/src/routes/workflows/reports/[slug]/+page.svelte
@@ -2,6 +2,7 @@
 	import type { PageData } from './$types';
 	import { range } from 'lodash-es';
 	import { formatTimestamp, formatTriggerDuration, parseForTable } from './utils';
+	import { normalizeErrorSample, type ErrorSample } from '@onaio/symbology-calc-core';
 	import PageHeader from '$lib/shared/components/PageHeader.svelte';
 	import { goto } from '$app/navigation';
 	import { toast } from '@zerodevx/svelte-toast';
@@ -62,7 +63,8 @@
 		// http status -> affected facility count, present only for network failures.
 		statusBreakdown?: Record<string, number>;
 		// sample underlying errors (url | status | message) with the time each occurred.
-		samples?: { at?: number; message: string }[];
+		// legacy reports (before timestamps) persisted these as plain strings.
+		samples?: (string | ErrorSample)[];
 	};
 
 	// TODO - below section DRY out these functions.
@@ -279,10 +281,11 @@
 													{#if row[1].samples}
 														<ul class="mb-0 small text-muted">
 															{#each row[1].samples as sample}
+																{@const normalized = normalizeErrorSample(sample)}
 																<li>
-																	{#if sample.at}<span class="fw-bold"
-																			>{formatTimestamp(sample.at)}</span
-																		> &mdash; {/if}{sample.message}
+																	{#if normalized.at}<span class="fw-bold"
+																			>{formatTimestamp(normalized.at)}</span
+																		> &mdash; {/if}{normalized.message}
 																</li>
 															{/each}
 														</ul>
@@ -329,10 +332,11 @@
 													{#if row[1].samples}
 														<ul class="mb-0 small text-muted">
 															{#each row[1].samples as sample}
+																{@const normalized = normalizeErrorSample(sample)}
 																<li>
-																	{#if sample.at}<span class="fw-bold"
-																			>{formatTimestamp(sample.at)}</span
-																		> &mdash; {/if}{sample.message}
+																	{#if normalized.at}<span class="fw-bold"
+																			>{formatTimestamp(normalized.at)}</span
+																		> &mdash; {/if}{normalized.message}
 																</li>
 															{/each}
 														</ul>

--- a/apps/web/src/routes/workflows/reports/[slug]/+page.svelte
+++ b/apps/web/src/routes/workflows/reports/[slug]/+page.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
 	import type { PageData } from './$types';
 	import { range } from 'lodash-es';
-	import { formatTriggerDuration, parseForTable } from './utils';
+	import { formatTimestamp, formatTriggerDuration, parseForTable } from './utils';
 	import PageHeader from '$lib/shared/components/PageHeader.svelte';
 	import { goto } from '$app/navigation';
 	import { toast } from '@zerodevx/svelte-toast';
@@ -61,8 +61,8 @@
 		description: string;
 		// http status -> affected facility count, present only for network failures.
 		statusBreakdown?: Record<string, number>;
-		// sample underlying error messages (url | status | message).
-		samples?: string[];
+		// sample underlying errors (url | status | message) with the time each occurred.
+		samples?: { at?: number; message: string }[];
 	};
 
 	// TODO - below section DRY out these functions.
@@ -279,7 +279,11 @@
 													{#if row[1].samples}
 														<ul class="mb-0 small text-muted">
 															{#each row[1].samples as sample}
-																<li>{sample}</li>
+																<li>
+																	{#if sample.at}<span class="fw-bold"
+																			>{formatTimestamp(sample.at)}</span
+																		> &mdash; {/if}{sample.message}
+																</li>
 															{/each}
 														</ul>
 													{/if}
@@ -325,7 +329,11 @@
 													{#if row[1].samples}
 														<ul class="mb-0 small text-muted">
 															{#each row[1].samples as sample}
-																<li>{sample}</li>
+																<li>
+																	{#if sample.at}<span class="fw-bold"
+																			>{formatTimestamp(sample.at)}</span
+																		> &mdash; {/if}{sample.message}
+																</li>
 															{/each}
 														</ul>
 													{/if}

--- a/packages/core/src/evaluator/configRunner.ts
+++ b/packages/core/src/evaluator/configRunner.ts
@@ -116,7 +116,7 @@ export class ConfigRunner {
               sanitizedCode,
               recsAffected ?? 0,
               sanitizedCode === NETWORK_ERROR
-                ? { httpStatus, errorSample: regFormSubmissionsResult.error }
+                ? { httpStatus, errorSample: regFormSubmissionsResult.error, errorTime: Date.now() }
                 : undefined
             );
           }
@@ -147,7 +147,8 @@ export class ConfigRunner {
                 resultCode === NETWORK_ERROR
                   ? {
                       httpStatus: failureDetail.httpStatus,
-                      errorSample: transformFacilityResult.error
+                      errorSample: transformFacilityResult.error,
+                      errorTime: Date.now()
                     }
                   : undefined
               );

--- a/packages/core/src/evaluator/metricReporter.ts
+++ b/packages/core/src/evaluator/metricReporter.ts
@@ -14,6 +14,16 @@ export interface FailureReportInput {
   httpStatus?: number;
   // a representative underlying error message (url | status | message).
   errorSample?: string;
+  // epoch millis of when the failure occurred, for display alongside the sample.
+  errorTime?: number;
+}
+
+// a single captured error: its underlying message and when it was first seen.
+export interface ErrorSample {
+  // epoch millis of when this error occurred (undefined if not supplied).
+  at?: number;
+  // the underlying error message (url | status | message).
+  message: string;
 }
 
 // accumulates the failure context seen for a single reason code.
@@ -21,8 +31,8 @@ interface FailureDetailAccumulator {
   // number of affected facilities per http status (key is the status, e.g. '500').
   // transport errors (timeout, DNS) have no http status and contribute no entry.
   statusBreakdown: Record<string, number>;
-  // a capped, de-duplicated list of underlying error messages.
-  samples: string[];
+  // a capped, de-duplicated (by message) list of underlying errors with timestamps.
+  samples: ErrorSample[];
 }
 
 export class ReportMetric {
@@ -67,7 +77,7 @@ export class ReportMetric {
     if (!detail) {
       return;
     }
-    const { httpStatus, errorSample } = detail;
+    const { httpStatus, errorSample, errorTime } = detail;
     if (httpStatus !== undefined) {
       const statusKey = `${httpStatus}`;
       accumulator.statusBreakdown[statusKey] =
@@ -76,9 +86,9 @@ export class ReportMetric {
     if (
       errorSample &&
       accumulator.samples.length < MAX_ERROR_SAMPLES &&
-      !accumulator.samples.includes(errorSample)
+      !accumulator.samples.some((sample) => sample.message === errorSample)
     ) {
-      accumulator.samples.push(errorSample);
+      accumulator.samples.push({ at: errorTime, message: errorSample });
     }
   }
 
@@ -94,7 +104,7 @@ export class ReportMetric {
       total: number;
       description: string;
       statusBreakdown?: Record<string, number>;
-      samples?: string[];
+      samples?: ErrorSample[];
     } = {
       total,
       description: ResultCodingsDescriptions[code] as string

--- a/packages/core/src/evaluator/metricReporter.ts
+++ b/packages/core/src/evaluator/metricReporter.ts
@@ -26,6 +26,12 @@ export interface ErrorSample {
   message: string;
 }
 
+/** Coerces a stored error sample to the current object shape. Reports persisted
+ * before timestamps were added hold plain message strings; normalize those to a
+ * timestamp-less { message } so consumers can treat all samples uniformly. */
+export const normalizeErrorSample = (sample: string | ErrorSample): ErrorSample =>
+  typeof sample === 'string' ? { message: sample } : sample;
+
 // accumulates the failure context seen for a single reason code.
 interface FailureDetailAccumulator {
   // number of affected facilities per http status (key is the status, e.g. '500').

--- a/packages/core/src/evaluator/tests/metricReporter.test.ts
+++ b/packages/core/src/evaluator/tests/metricReporter.test.ts
@@ -6,26 +6,33 @@ const getNotModified = (reporter: ReportMetric) =>
 const getNotEvaluated = (reporter: ReportMetric) =>
   (reporter.generateJsonReport() as any).facilitiesNotEvaluated;
 
-it('aggregates an http status breakdown and sample messages for network errors', () => {
+it('aggregates an http status breakdown and timestamped sample messages for network errors', () => {
   const reporter = new ReportMetric('uuid');
   reporter.updateEvaluatedNotModified(NETWORK_ERROR, {
     httpStatus: 500,
-    errorSample: 'URL: a | Status: 500'
+    errorSample: 'URL: a | Status: 500',
+    errorTime: 1000
   });
   reporter.updateEvaluatedNotModified(NETWORK_ERROR, {
     httpStatus: 500,
-    errorSample: 'URL: b | Status: 500'
+    errorSample: 'URL: b | Status: 500',
+    errorTime: 2000
   });
   reporter.updateEvaluatedNotModified(NETWORK_ERROR, {
     httpStatus: 429,
-    errorSample: 'URL: c | Status: 429'
+    errorSample: 'URL: c | Status: 429',
+    errorTime: 3000
   });
 
   expect(getNotModified(reporter)[NETWORK_ERROR]).toEqual({
     total: 3,
     description: 'Request failed due to an unrecoverable network error',
     statusBreakdown: { '500': 2, '429': 1 },
-    samples: ['URL: a | Status: 500', 'URL: b | Status: 500', 'URL: c | Status: 429']
+    samples: [
+      { at: 1000, message: 'URL: a | Status: 500' },
+      { at: 2000, message: 'URL: b | Status: 500' },
+      { at: 3000, message: 'URL: c | Status: 429' }
+    ]
   });
 });
 
@@ -42,13 +49,14 @@ it('omits breakdown fields for non-network reasons', () => {
 it('records a status entry but no samples for transport errors without an http status', () => {
   const reporter = new ReportMetric('uuid');
   reporter.updateEvaluatedNotModified(NETWORK_ERROR, {
-    errorSample: 'Error Name: FetchError | Message: request timed out'
+    errorSample: 'Error Name: FetchError | Message: request timed out',
+    errorTime: 4242
   });
 
   expect(getNotModified(reporter)[NETWORK_ERROR]).toEqual({
     total: 1,
     description: 'Request failed due to an unrecoverable network error',
-    samples: ['Error Name: FetchError | Message: request timed out']
+    samples: [{ at: 4242, message: 'Error Name: FetchError | Message: request timed out' }]
   });
 });
 
@@ -73,33 +81,46 @@ it('accumulates not-evaluated counts across failed pages, consistent with the br
   const reporter = new ReportMetric('uuid');
   reporter.updateFacilitiesNotEvaluated(NETWORK_ERROR, 1000, {
     httpStatus: 500,
-    errorSample: 'page-1'
+    errorSample: 'page-1',
+    errorTime: 1000
   });
   reporter.updateFacilitiesNotEvaluated(NETWORK_ERROR, 1000, {
     httpStatus: 500,
-    errorSample: 'page-2'
+    errorSample: 'page-2',
+    errorTime: 2000
   });
 
   const entry = getNotEvaluated(reporter)[NETWORK_ERROR];
   expect(entry.total).toEqual(2000);
   expect(entry.statusBreakdown).toEqual({ '500': 2000 });
-  expect(entry.samples).toEqual(['page-1', 'page-2']);
+  expect(entry.samples).toEqual([
+    { at: 1000, message: 'page-1' },
+    { at: 2000, message: 'page-2' }
+  ]);
 });
 
 it('does not let a yielded report mutate when the reporter keeps accumulating', () => {
   const reporter = new ReportMetric('uuid');
-  reporter.updateEvaluatedNotModified(NETWORK_ERROR, { httpStatus: 500, errorSample: 'first' });
+  reporter.updateEvaluatedNotModified(NETWORK_ERROR, {
+    httpStatus: 500,
+    errorSample: 'first',
+    errorTime: 1000
+  });
 
   const firstReport = getNotModified(reporter)[NETWORK_ERROR];
 
   // keep running: another failure of the same code arrives.
-  reporter.updateEvaluatedNotModified(NETWORK_ERROR, { httpStatus: 429, errorSample: 'second' });
+  reporter.updateEvaluatedNotModified(NETWORK_ERROR, {
+    httpStatus: 429,
+    errorSample: 'second',
+    errorTime: 2000
+  });
 
   // the previously-yielded report must be unchanged.
   expect(firstReport).toEqual({
     total: 1,
     description: 'Request failed due to an unrecoverable network error',
     statusBreakdown: { '500': 1 },
-    samples: ['first']
+    samples: [{ at: 1000, message: 'first' }]
   });
 });

--- a/packages/core/src/evaluator/tests/metricReporter.test.ts
+++ b/packages/core/src/evaluator/tests/metricReporter.test.ts
@@ -1,4 +1,4 @@
-import { ReportMetric } from '../metricReporter';
+import { normalizeErrorSample, ReportMetric } from '../metricReporter';
 import { MISSING_PRIORITY_LEVEL, NETWORK_ERROR } from '../../helpers/Result';
 
 const getNotModified = (reporter: ReportMetric) =>
@@ -122,5 +122,19 @@ it('does not let a yielded report mutate when the reporter keeps accumulating', 
     description: 'Request failed due to an unrecoverable network error',
     statusBreakdown: { '500': 1 },
     samples: [{ at: 1000, message: 'first' }]
+  });
+});
+
+describe('normalizeErrorSample', () => {
+  it('wraps a legacy string sample into the current object shape', () => {
+    // reports persisted before timestamps were added hold plain message strings.
+    expect(normalizeErrorSample('URL: a | Status: 500')).toEqual({
+      message: 'URL: a | Status: 500'
+    });
+  });
+
+  it('passes through an already-normalized sample unchanged', () => {
+    const sample = { at: 1000, message: 'URL: a | Status: 500' };
+    expect(normalizeErrorSample(sample)).toBe(sample);
   });
 });

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,4 +1,5 @@
 export * from './evaluator/configRunner';
+export * from './evaluator/metricReporter';
 export * from './evaluator/pipelinesController';
 export * from './helpers/types';
 export * from './helpers/utils';


### PR DESCRIPTION
## Problem

Building on the network-error detail added in #19, the report's error samples showed the failing URL, status, and message — but **not when each error occurred**. The exact time was only available by cross-referencing the timestamped log file.

## Change

- **Capture** — `configRunner` stamps `Date.now()` (as `errorTime`) when it records a network failure, for both the per-facility (not modified) and bulk-fetch (not evaluated) paths.
- **Store** — `ReportMetric` samples change from `string[]` to `ErrorSample[]` (`{ at?, message }`), still de-duplicated by message (first occurrence's time kept) and capped at 5.
- **Render** — the report's Details column now shows the formatted timestamp (via the existing `formatTimestamp` helper) before each sample message, e.g. `6/10/2026, 12:03:41 PM — Request failed for | URL: … | Status: 429`.

## Verification

- Core tests: 24/24 pass (reporter unit tests updated for the new `{ at, message }` sample shape).
- Core typecheck (`tsc --noEmit`): clean.
- Web `svelte-check`: report page holds at 14 pre-existing errors (stale `Metric` type, unrelated) — this change adds zero new errors.

## Note

Timestamps are stored as epoch millis in the report JSON and formatted in the UI, consistent with how `trigger.from`/`trigger.to` are already handled.